### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,9 +85,9 @@
     "kuark-schema": "0.0.9",
     "lodash": "^4.7.0",
     "mssql": "^3.1.2",
-    "node-uuid": "^1.4.7",
     "q": "^1.4.1",
     "redis": "2.5.3",
+    "uuid": "^3.0.0",
     "winston": "^2.2.0",
     "winston-elasticsearch": "^0.2.6",
     "winston-redis": "^1.0.0"

--- a/src/db_uyariServisi.js
+++ b/src/db_uyariServisi.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uuid = require('node-uuid'),
+var uuid = require('uuid'),
     schema = require('kuark-schema'),
     _ = require('lodash'),
     extensions = require('kuark-extensions'),

--- a/test/db_ihaleSpec.js
+++ b/test/db_ihaleSpec.js
@@ -6,7 +6,7 @@ var db = require("../src/index")(),
     assert = chai.assert,
     schema = require("kuark-schema"),
     extensions = require('kuark-extensions'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     l = extensions.winstonConfig;
 
 

--- a/test/db_tahtaSpec.js
+++ b/test/db_tahtaSpec.js
@@ -4,7 +4,7 @@ var db = require("../src/index")(),
     assert = require('chai').assert,
     schema = require("kuark-schema"),
     extension = require('kuark-extensions'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     l = extension.winstonConfig;
 
 describe("DB Tahta İşlemleri", function () {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.